### PR TITLE
Updated substrait-usage.md to include the unsupported Arrow and Subst…

### DIFF
--- a/docs/substrait-usage.md
+++ b/docs/substrait-usage.md
@@ -114,6 +114,23 @@ Bidirectional conversion between Substrait protobuf literals and Java/Arrow type
 
 Supported types: i8, i16, i32, i64, fp32, fp64, string, boolean, binary, decimal, date, timestamp, varchar, fixed_char.
 
+**Unsupported Substrait Literal Types** (`extractLiteralValue` — throws `UnsupportedOperationException`):
+
+| Category | Types |
+|---|---|
+| Numeric | `UUID`, `INTERVAL_YEAR_TO_MONTH`, `INTERVAL_DAY_TO_SECOND` |
+| Temporal | `TIME`, `PRECISION_TIMESTAMP`, `PRECISION_TIMESTAMP_TZ` |
+| Complex/Structured | `LIST`, `MAP`, `STRUCT`, `EMPTY_LIST`, `EMPTY_MAP`, `NULL` |
+| Other | `FIXED_BINARY`, `USER_DEFINED` |
+
+**Unsupported Arrow Type IDs** (`createLiteralExpression` — throws `IllegalArgumentException`):
+
+| Category | Types |
+|---|---|
+| Temporal | `Time`, `Duration`, `Interval` |
+| Complex/Structured | `List`, `Map`, `Struct`, `Union`, `LargeList`, `ListView` |
+| Other | `FixedSizeBinary`, `LargeBinary`, `LargeUtf8`, `Null`, `NONE` |
+
 ### `SubstraitMetadataParser`
 
 Extracts table column names from the `ReadRel`'s base schema, including support for nested struct types.


### PR DESCRIPTION
…rait types

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
